### PR TITLE
Chore randomiser

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 text eol=lf
+* text=auto

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -1,6 +1,7 @@
 export const ROUTE_ROOT = "/";
 export const ROUTE_PRODUCT_LIST_PAGE = "/list";
 export const ROUTE_MEAL_PAGE = "/meal";
+export const ROUTE_CHORES_PAGE = "/chores";
 export const ROUTE_LOGIN_PAGE = "/login";
 export const ROUTE_MEAL_EDIT_PAGE = "/meal/edit/:id";
 export const ROUTE_MEAL_CREATE_PAGE = "/meal/create";

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -5,3 +5,5 @@ export const ROUTE_CHORES_PAGE = "/chores";
 export const ROUTE_LOGIN_PAGE = "/login";
 export const ROUTE_MEAL_EDIT_PAGE = "/meal/edit/:id";
 export const ROUTE_MEAL_CREATE_PAGE = "/meal/create";
+export const ROUTE_CHORE_EDIT_PAGE = "/chores/edit/:id";
+export const ROUTE_CHORE_CREATE_PAGE = "/chores/create";

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -6,6 +6,7 @@ import {
   ROUTE_MEAL_EDIT_PAGE,
   ROUTE_MEAL_PAGE,
   ROUTE_PRODUCT_LIST_PAGE,
+  ROUTE_CHORES_PAGE,
   ROUTE_ROOT,
 } from "./constants";
 import AuthRoute from "./AuthRoute";
@@ -16,6 +17,7 @@ const Login = lazy(() => import("Views/LoginView"));
 const Dashboard = lazy(() => import("Views/Dashboard"));
 const MealList = lazy(() => import("Views/MealView"));
 const ProductList = lazy(() => import("Views/ProductListView"));
+const ChoresView = lazy(() => import("Views/ChoresView"));
 
 const App = () => (
   <Routes>
@@ -64,6 +66,14 @@ const App = () => (
       element={
         <AuthRoute>
           <ProductList />
+        </AuthRoute>
+      }
+    />
+    <Route
+      path={ROUTE_CHORES_PAGE}
+      element={
+        <AuthRoute>
+          <ChoresView />
         </AuthRoute>
       }
     />

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -7,11 +7,14 @@ import {
   ROUTE_MEAL_PAGE,
   ROUTE_PRODUCT_LIST_PAGE,
   ROUTE_CHORES_PAGE,
+  ROUTE_CHORE_CREATE_PAGE,
+  ROUTE_CHORE_EDIT_PAGE,
   ROUTE_ROOT,
 } from "./constants";
 import AuthRoute from "./AuthRoute";
 import { PublicRoute } from "./PublicRoute";
 import MealForm from "Views/MealView/MealForm";
+import ChoreForm from "Views/ChoresView/ChoreForm";
 
 const Login = lazy(() => import("Views/LoginView"));
 const Dashboard = lazy(() => import("Views/Dashboard"));
@@ -66,6 +69,22 @@ const App = () => (
       element={
         <AuthRoute>
           <ProductList />
+        </AuthRoute>
+      }
+    />
+    <Route
+      path={ROUTE_CHORE_EDIT_PAGE}
+      element={
+        <AuthRoute>
+          <ChoreForm />
+        </AuthRoute>
+      }
+    />
+    <Route
+      path={ROUTE_CHORE_CREATE_PAGE}
+      element={
+        <AuthRoute>
+          <ChoreForm />
         </AuthRoute>
       }
     />

--- a/src/Components/Box/index.tsx
+++ b/src/Components/Box/index.tsx
@@ -3,6 +3,7 @@ import Loader from "../Loader";
 import style from "./style.scss";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import classnames from "classnames";
 
 interface Props {
   id?: string;
@@ -43,15 +44,14 @@ const Box = forwardRef<Elements, Props>(
 
     const boxContent = (
       <>
-        {title && dropdownComponent && (
-          <div className={style.boxHeader}>
-            <h2 className={style.boxTitle}>{title}</h2>
-            {dropdownComponent}
-          </div>
-        )}
-        {title && !dropdownComponent && (
-          <h2 className={style.boxTitle}>{title}</h2>
-        )}
+        <div
+          className={classnames(style.boxHeader, {
+            [style.right]: !title && dropdownComponent,
+          })}
+        >
+          {title && <h2 className={style.boxTitle}>{title}</h2>}
+          {dropdownComponent}
+        </div>
         {children}
       </>
     );

--- a/src/Components/Box/index.tsx
+++ b/src/Components/Box/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ElementRef, forwardRef, ReactNode } from "react";
+import { CSSProperties, forwardRef, ReactNode, Ref } from "react";
 import Loader from "../Loader";
 import style from "./style.scss";
 import { useSortable } from "@dnd-kit/sortable";
@@ -14,22 +14,18 @@ interface Props {
   dropdownComponent?: ReactNode;
 }
 
-const Box = forwardRef<
-  ElementRef<"div"> | ElementRef<"p"> | ElementRef<"li">,
-  Props
->(
-  (
-    {
-      as: Component,
-      id,
-      title,
-      children,
-      isLoading = false,
-      isDraggable,
-      dropdownComponent,
-    },
-    ref: any,
-  ) => {
+type Elements = HTMLDivElement | HTMLParagraphElement | HTMLLIElement;
+
+const Box = forwardRef<Elements, Props>(
+  ({
+    as: Component,
+    id,
+    title,
+    children,
+    isLoading = false,
+    isDraggable,
+    dropdownComponent,
+  }) => {
     const {
       attributes,
       isDragging,
@@ -79,7 +75,7 @@ const Box = forwardRef<
     }
 
     return (
-      <Component ref={ref} className={style.box}>
+      <Component ref={setNodeRef} className={style.box}>
         {isLoading && <Loader />}
         {!isLoading && boxContent}
       </Component>

--- a/src/Components/Box/style.scss
+++ b/src/Components/Box/style.scss
@@ -26,4 +26,8 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
+
+  &.right {
+    justify-content: flex-end;
+  }
 }

--- a/src/Components/Sidebar/SidebarContent.tsx
+++ b/src/Components/Sidebar/SidebarContent.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { ROUTE_MEAL_PAGE, ROUTE_PRODUCT_LIST_PAGE } from "App/constants";
+import {
+  ROUTE_MEAL_PAGE,
+  ROUTE_PRODUCT_LIST_PAGE,
+  ROUTE_CHORES_PAGE,
+} from "App/constants";
 import style from "./style.scss";
 import Kitchen from "Images/icons/kitchen.svg";
 import SidebarItem from "./SidebarItem";
 
-const kitchenLinkMap = [
+const cookingLinkMap = [
   {
     key: "meal_view",
     name: "Meal list",
@@ -17,12 +21,26 @@ const kitchenLinkMap = [
   },
 ];
 
+const choresLinkMap = [
+  {
+    key: "chores_view",
+    name: "Chores",
+    pathname: ROUTE_CHORES_PAGE,
+  },
+];
+
 const itemMap = [
   {
-    title: "Kitchen",
+    title: "Cooking",
     icon: <Kitchen />,
-    routes: kitchenLinkMap,
+    routes: cookingLinkMap,
     defaultPath: ROUTE_PRODUCT_LIST_PAGE,
+  },
+  {
+    title: "Chores",
+    icon: <Kitchen />,
+    routes: choresLinkMap,
+    defaultPath: ROUTE_CHORES_PAGE,
   },
 ];
 

--- a/src/Images/icons/dice.svg
+++ b/src/Images/icons/dice.svg
@@ -1,0 +1,25 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- Back die (outlined, tilted) -->
+  <g transform="translate(0.5,0.8) rotate(-18, 9, 9)">
+    <rect x="2" y="2" width="14" height="14" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <!-- 5 pips -->
+    <circle cx="6" cy="6" r="1.4" fill="currentColor"/>
+    <circle cx="12" cy="6" r="1.4" fill="currentColor"/>
+    <circle cx="6" cy="12" r="1.4" fill="currentColor"/>
+    <circle cx="12" cy="12" r="1.4" fill="currentColor"/>
+    <circle cx="9" cy="9" r="1.4" fill="currentColor"/>
+  </g>
+
+  <!-- Front die (outlined, tilted the other way) -->
+  <g transform="translate(8.2,6.2) rotate(12, 7, 7)">
+    <rect x="0" y="0" width="14" height="14" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <!-- 6 pips -->
+    <circle cx="4" cy="3.5" r="1.3" fill="currentColor"/>
+    <circle cx="10" cy="3.5" r="1.3" fill="currentColor"/>
+    <circle cx="4" cy="7" r="1.3" fill="currentColor"/>
+    <circle cx="10" cy="7" r="1.3" fill="currentColor"/>
+    <circle cx="4" cy="10.5" r="1.3" fill="currentColor"/>
+    <circle cx="10" cy="10.5" r="1.3" fill="currentColor"/>
+  </g>
+</svg>
+

--- a/src/Schema/mutations/chore.mutations.ts
+++ b/src/Schema/mutations/chore.mutations.ts
@@ -1,0 +1,62 @@
+import { gql } from "@apollo/client";
+import {
+  ChoreCreateMutation,
+  ChoreCreateMutationVariables,
+  ChoreDeleteMutation,
+  ChoreDeleteMutationVariables,
+  ChoreSaveMutation,
+  ChoreSaveMutationVariables,
+  ChoreTakeMutation,
+  ChoreTakeMutationVariables,
+} from "Schema/types";
+import { MutationDocument } from "Utilities/typesExport";
+
+export const CHORE_CREATE_MUTATION: MutationDocument<
+  ChoreCreateMutation,
+  ChoreCreateMutationVariables
+> = gql`
+  mutation choreCreate($id: String, $name: String!) {
+    createChore(id: $id, name: $name) {
+      id
+      name
+      timestamp
+    }
+  }
+`;
+
+export const CHORE_SAVE_MUTATION: MutationDocument<
+  ChoreSaveMutation,
+  ChoreSaveMutationVariables
+> = gql`
+  mutation choreSave($id: ID!, $name: String!) {
+    saveChore(id: $id, name: $name) {
+      id
+      name
+      timestamp
+    }
+  }
+`;
+
+export const CHORE_DELETE_MUTATION: MutationDocument<
+  ChoreDeleteMutation,
+  ChoreDeleteMutationVariables
+> = gql`
+  mutation choreDelete($id: ID!) {
+    deleteChore(id: $id) {
+      success
+    }
+  }
+`;
+
+export const CHORE_TAKE_MUTATION: MutationDocument<
+  ChoreTakeMutation,
+  ChoreTakeMutationVariables
+> = gql`
+  mutation choreTake($id: ID!) {
+    takeChore(id: $id) {
+      id
+      name
+      timestamp
+    }
+  }
+`;

--- a/src/Schema/queries/chore.queries.ts
+++ b/src/Schema/queries/chore.queries.ts
@@ -1,0 +1,16 @@
+import { gql } from "@apollo/client";
+import { ChoreListQuery, ChoreListQueryVariables } from "Schema/types";
+import { QueryDocument } from "Utilities/typesExport";
+
+export const CHORE_LIST_DATA: QueryDocument<
+  ChoreListQuery,
+  ChoreListQueryVariables
+> = gql`
+  query choreList {
+    chores {
+      id
+      name
+      timestamp
+    }
+  }
+`;

--- a/src/Schema/queries/chore.queries.ts
+++ b/src/Schema/queries/chore.queries.ts
@@ -6,8 +6,8 @@ export const CHORE_LIST_DATA: QueryDocument<
   ChoreListQuery,
   ChoreListQueryVariables
 > = gql`
-  query choreList {
-    chores {
+  query choreList($days: Int) {
+    chores(days: $days) {
       id
       name
       timestamp

--- a/src/Schema/types.ts
+++ b/src/Schema/types.ts
@@ -24,7 +24,7 @@ export type Chore = {
   __typename?: 'Chore';
   id: Scalars['ID']['output'];
   name?: Maybe<Scalars['String']['output']>;
-  timestamp?: Maybe<Scalars['Int']['output']>;
+  timestamp?: Maybe<Scalars['String']['output']>;
 };
 
 export type IngredientInput = {
@@ -183,7 +183,7 @@ export type ChoreCreateMutationVariables = Exact<{
 }>;
 
 
-export type ChoreCreateMutation = { __typename?: 'Mutation', createChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null } };
+export type ChoreCreateMutation = { __typename?: 'Mutation', createChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: string | null } };
 
 export type ChoreSaveMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -191,7 +191,7 @@ export type ChoreSaveMutationVariables = Exact<{
 }>;
 
 
-export type ChoreSaveMutation = { __typename?: 'Mutation', saveChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null } };
+export type ChoreSaveMutation = { __typename?: 'Mutation', saveChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: string | null } };
 
 export type ChoreDeleteMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -205,7 +205,7 @@ export type ChoreTakeMutationVariables = Exact<{
 }>;
 
 
-export type ChoreTakeMutation = { __typename?: 'Mutation', takeChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null } };
+export type ChoreTakeMutation = { __typename?: 'Mutation', takeChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: string | null } };
 
 export type MealMutationMutationVariables = Exact<{
   id?: InputMaybe<Scalars['String']['input']>;
@@ -287,7 +287,7 @@ export type ProductCompleteMutation = { __typename?: 'Mutation', completeProduct
 export type ChoreListQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ChoreListQuery = { __typename?: 'Query', chores?: Array<{ __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null }> | null };
+export type ChoreListQuery = { __typename?: 'Query', chores?: Array<{ __typename?: 'Chore', id: string, name?: string | null, timestamp?: string | null }> | null };
 
 export type UserDataQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/Schema/types.ts
+++ b/src/Schema/types.ts
@@ -20,6 +20,13 @@ export enum CacheControlScope {
   Public = 'PUBLIC'
 }
 
+export type Chore = {
+  __typename?: 'Chore';
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+  timestamp?: Maybe<Scalars['Int']['output']>;
+};
+
 export type IngredientInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
@@ -42,12 +49,16 @@ export type Mutation = {
   attachMealToProductMutation?: Maybe<Product>;
   cancelProductList?: Maybe<Null>;
   completeProduct: Product;
+  createChore: Chore;
   createMeal: Meal;
   createProduct: Product;
+  deleteChore?: Maybe<Null>;
   deleteMeal?: Maybe<Null>;
   deleteProduct?: Maybe<Null>;
   editMeal?: Maybe<Null>;
   renameProduct: Product;
+  saveChore: Chore;
+  takeChore: Chore;
   updateListOrderMutation?: Maybe<Array<Product>>;
 };
 
@@ -63,6 +74,12 @@ export type MutationCompleteProductArgs = {
 };
 
 
+export type MutationCreateChoreArgs = {
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+};
+
+
 export type MutationCreateMealArgs = {
   id?: InputMaybe<Scalars['String']['input']>;
   ingredients?: InputMaybe<Array<InputMaybe<IngredientInput>>>;
@@ -75,6 +92,11 @@ export type MutationCreateProductArgs = {
   id?: InputMaybe<Scalars['String']['input']>;
   isDone?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteChoreArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -102,6 +124,17 @@ export type MutationRenameProductArgs = {
 };
 
 
+export type MutationSaveChoreArgs = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+};
+
+
+export type MutationTakeChoreArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type MutationUpdateListOrderMutationArgs = {
   newList?: InputMaybe<Array<InputMaybe<ProductInput>>>;
 };
@@ -126,6 +159,7 @@ export type ProductInput = {
 
 export type Query = {
   __typename?: 'Query';
+  chores?: Maybe<Array<Chore>>;
   meals?: Maybe<Array<Meal>>;
   products?: Maybe<Array<Product>>;
   userDashboard: UserDashboard;
@@ -142,6 +176,36 @@ export type UserDashboard = {
   __typename?: 'UserDashboard';
   username?: Maybe<Scalars['String']['output']>;
 };
+
+export type ChoreCreateMutationVariables = Exact<{
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+}>;
+
+
+export type ChoreCreateMutation = { __typename?: 'Mutation', createChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null } };
+
+export type ChoreSaveMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+}>;
+
+
+export type ChoreSaveMutation = { __typename?: 'Mutation', saveChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null } };
+
+export type ChoreDeleteMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type ChoreDeleteMutation = { __typename?: 'Mutation', deleteChore?: { __typename?: 'Null', success?: boolean | null } | null };
+
+export type ChoreTakeMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type ChoreTakeMutation = { __typename?: 'Mutation', takeChore: { __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null } };
 
 export type MealMutationMutationVariables = Exact<{
   id?: InputMaybe<Scalars['String']['input']>;
@@ -219,6 +283,11 @@ export type ProductCompleteMutationVariables = Exact<{
 
 
 export type ProductCompleteMutation = { __typename?: 'Mutation', completeProduct: { __typename?: 'Product', id: string, name?: string | null, isDone?: boolean | null } };
+
+export type ChoreListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ChoreListQuery = { __typename?: 'Query', chores?: Array<{ __typename?: 'Chore', id: string, name?: string | null, timestamp?: number | null }> | null };
 
 export type UserDataQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/Views/ChoresView/ChoreForm.tsx
+++ b/src/Views/ChoresView/ChoreForm.tsx
@@ -1,0 +1,141 @@
+import { Helmet } from "react-helmet-async";
+import { useParams, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import Button from "Components/Button";
+import Input from "Components/Input";
+import useMutation from "Hooks/useMutation";
+import useQuery from "Hooks/useQuery";
+import {
+  CHORE_CREATE_MUTATION,
+  CHORE_SAVE_MUTATION,
+} from "Schema/mutations/chore.mutations";
+import { CHORE_LIST_DATA } from "Schema/queries/chore.queries";
+import Loader from "Components/Loader";
+import ErrorHandler from "Components/ErrorHandler";
+import style from "./style.scss";
+
+const ChoreForm = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [choreName, setChoreName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const [createChore, createChoreData] = useMutation(CHORE_CREATE_MUTATION);
+  const [saveChore, saveChoreData] = useMutation(CHORE_SAVE_MUTATION);
+
+  const { loading, error, data } = useQuery(CHORE_LIST_DATA, {
+    skip: !id, // Only fetch if we're in edit mode
+  });
+
+  const isEdit = !!id;
+
+  // Prefill chore name when in edit mode
+  useEffect(() => {
+    if (isEdit && data?.chores) {
+      const chore = data.chores.find((c) => c.id === id);
+      if (chore?.name) {
+        setChoreName(chore.name);
+      }
+    }
+  }, [isEdit, data, id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!choreName.trim()) return;
+
+    setIsSubmitting(true);
+
+    if (isEdit) {
+      await saveChore({
+        variables: {
+          id,
+          name: choreName.trim(),
+        },
+        update: () => {
+          setIsSubmitting(false);
+          setIsSuccess(true);
+          setTimeout(() => {
+            navigate("/chores");
+          }, 1500);
+        },
+      });
+    } else {
+      await createChore({
+        variables: {
+          name: choreName.trim(),
+        },
+        update: () => {
+          setIsSubmitting(false);
+          setIsSuccess(true);
+          setTimeout(() => {
+            navigate("/chores");
+          }, 1500);
+        },
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    navigate("/chores");
+  };
+
+  if (isEdit && loading) return <Loader />;
+  if (isEdit && error) return <ErrorHandler error={error} />;
+
+  return (
+    <>
+      <Helmet title={`${isEdit ? "Edit" : "Create"} Chore | Imli`} />
+      <div className={style.choreFormContainer}>
+        <div className={style.choreFormWrapper}>
+          <h2 className={style.choreFormTitle}>
+            {isEdit ? "Edit Chore" : "Create New Chore"}
+          </h2>
+          <form onSubmit={handleSubmit} className={style.choreForm}>
+            <div className={style.choreFormField}>
+              <label htmlFor="choreName">Chore Name</label>
+              <Input
+                id="choreName"
+                type="text"
+                value={choreName}
+                onChange={(e) => setChoreName(e.target.value)}
+                placeholder="Enter chore name"
+                required
+              />
+            </div>
+            {isSuccess && (
+              <p className={style.addSuccessful}>
+                {isEdit
+                  ? "Chore updated successfully!"
+                  : "Chore created successfully!"}
+              </p>
+            )}
+            <div className={style.choreFormButtons}>
+              <Button
+                type="button"
+                buttonStyle="hollow"
+                onClick={handleCancel}
+                isDisabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                buttonStyle="prime"
+                isDisabled={isSubmitting || !choreName.trim()}
+              >
+                {isSubmitting
+                  ? "Saving..."
+                  : isEdit
+                  ? "Update Chore"
+                  : "Create Chore"}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ChoreForm;

--- a/src/Views/ChoresView/ChoreListItem.tsx
+++ b/src/Views/ChoresView/ChoreListItem.tsx
@@ -1,0 +1,93 @@
+import Box from "Components/Box";
+import style from "./style.scss";
+import DeleteChoreModal from "Views/ChoresView/DeleteChoreModal";
+import Delete from "Images/icons/delete.svg";
+import Edit from "Images/icons/edit.svg";
+import useState from "Hooks/useState";
+import { ChoreListQuery } from "Schema/types";
+import { DeepExtractTypeSkipArrays } from "Declarations/typeExtract";
+import Dropdown from "Components/Dropdown";
+import Button from "Components/Button";
+import { SyntheticEvent } from "react";
+
+interface Props {
+  onEdit: (id: string) => void;
+  onDelete: () => void;
+  data?: DeepExtractTypeSkipArrays<ChoreListQuery, ["chores"]>;
+}
+
+interface State {
+  isDeleteModalOpen: boolean;
+}
+
+const ChoreListItem = ({ data, onDelete, onEdit }: Props) => {
+  const [state, setState] = useState<State>({
+    isDeleteModalOpen: false,
+  });
+
+  const toggleDeleteModal = () => {
+    setState({
+      isDeleteModalOpen: !state.isDeleteModalOpen,
+    });
+  };
+
+  const handleOnEdit = (e: SyntheticEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onEdit(data.id);
+  };
+
+  const formatTimestamp = (timestamp?: string | null) => {
+    if (!timestamp) return "No timestamp";
+    const timestampNum = parseInt(timestamp, 10);
+    if (isNaN(timestampNum)) return "Invalid timestamp";
+    return new Date(timestampNum).toLocaleDateString();
+  };
+
+  return (
+    <>
+      <li className={style.choreListItem}>
+        <div className={style.choreListItemButton}>
+          <Box
+            as="div"
+            title={data?.name}
+            dropdownComponent={
+              <Dropdown>
+                <Button
+                  buttonStyle="none"
+                  onMouseDown={handleOnEdit}
+                  className={style.choreListItemOption}
+                >
+                  {"Edit"}
+                  <Edit height="16px" />
+                </Button>
+                <Button
+                  buttonStyle="none"
+                  onClick={toggleDeleteModal}
+                  className={style.choreListItemOption}
+                >
+                  {"Delete"}
+                  <Delete height="16px" />
+                </Button>
+              </Dropdown>
+            }
+          >
+            <div className={style.choreListItemContent}>
+              <h3 className={style.choreListItemName}>{data?.name}</h3>
+              <p className={style.choreListItemTimestamp}>
+                Created: {formatTimestamp(data?.timestamp)}
+              </p>
+            </div>
+          </Box>
+        </div>
+      </li>
+      <DeleteChoreModal
+        id={data?.id}
+        onChange={onDelete}
+        onClose={toggleDeleteModal}
+        isOpen={state.isDeleteModalOpen}
+      />
+    </>
+  );
+};
+
+export default ChoreListItem;

--- a/src/Views/ChoresView/ChoreListItem.tsx
+++ b/src/Views/ChoresView/ChoreListItem.tsx
@@ -49,7 +49,6 @@ const ChoreListItem = ({ data, onDelete, onEdit }: Props) => {
         <div className={style.choreListItemButton}>
           <Box
             as="div"
-            title={data?.name}
             dropdownComponent={
               <Dropdown>
                 <Button
@@ -72,10 +71,7 @@ const ChoreListItem = ({ data, onDelete, onEdit }: Props) => {
             }
           >
             <div className={style.choreListItemContent}>
-              <h3 className={style.choreListItemName}>{data?.name}</h3>
-              <p className={style.choreListItemTimestamp}>
-                Created: {formatTimestamp(data?.timestamp)}
-              </p>
+              <p>{data.name}</p>
             </div>
           </Box>
         </div>

--- a/src/Views/ChoresView/DeleteChoreModal.tsx
+++ b/src/Views/ChoresView/DeleteChoreModal.tsx
@@ -1,0 +1,44 @@
+import withModal, { ModalProps } from "HOC/withModal";
+import Button from "Components/Button";
+import useMutation from "Hooks/useMutation";
+import { CHORE_DELETE_MUTATION } from "Schema/mutations/chore.mutations";
+import style from "./style.scss";
+
+interface Props extends ModalProps {
+  id?: string;
+  onChange: () => void;
+}
+
+const DeleteChoreModal = ({ id, onChange }: Props) => {
+  const [deleteChore, deleteChoreData] = useMutation(CHORE_DELETE_MUTATION);
+
+  const handleDelete = () => {
+    if (id) {
+      deleteChore({
+        variables: {
+          id,
+        },
+        update: () => onChange(),
+      });
+    }
+  };
+
+  return (
+    <div className={style.deleteModalContent}>
+      <h3 className={style.deleteModalTitle}>Delete Chore</h3>
+      <p>Are you sure you want to delete this chore?</p>
+      <div className={style.deleteModalButtons}>
+        <Button
+          buttonStyle="hollow"
+          onClick={handleDelete}
+          isLoading={deleteChoreData.loading}
+          className={style.deleteModalButton}
+        >
+          Delete
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default withModal(DeleteChoreModal);

--- a/src/Views/ChoresView/PickChoreModal.tsx
+++ b/src/Views/ChoresView/PickChoreModal.tsx
@@ -1,0 +1,95 @@
+import withModal, { ModalProps } from "HOC/withModal";
+import Button from "Components/Button";
+import style from "./style.scss";
+import useState from "Hooks/useState";
+import { useEffect, useMemo } from "react";
+import useMutation from "Hooks/useMutation";
+import { CHORE_TAKE_MUTATION } from "Schema/mutations/chore.mutations";
+
+interface ChoreItem {
+  id: string;
+  name?: string | null;
+}
+
+interface Props extends ModalProps {
+  chores: ChoreItem[];
+  onTaken: () => void;
+}
+
+interface State {
+  selectedChore?: ChoreItem | null;
+}
+
+const getRandomIndex = (max: number) => {
+  return Math.floor(Math.random() * max);
+};
+
+const PickChoreModal = ({ chores, onTaken }: Props) => {
+  const [state, setState] = useState<State>({ selectedChore: null });
+  const [takeChore, takeChoreData] = useMutation(CHORE_TAKE_MUTATION);
+
+  const availableChores = useMemo(() => chores || [], [chores]);
+
+  useEffect(() => {
+    if (availableChores.length) {
+      const idx = getRandomIndex(availableChores.length);
+      setState({ selectedChore: availableChores[idx] });
+    } else {
+      setState({ selectedChore: null });
+    }
+  }, [availableChores]);
+
+  const handlePass = () => {
+    if (!availableChores.length) return;
+    if (availableChores.length === 1) {
+      setState({ selectedChore: availableChores[0] });
+      return;
+    }
+
+    let nextIndex = getRandomIndex(availableChores.length);
+    if (state.selectedChore) {
+      // avoid repeating the same selection if possible
+      const currentIndex = availableChores.findIndex(
+        (c) => c.id === state.selectedChore?.id,
+      );
+      if (currentIndex !== -1 && nextIndex === currentIndex) {
+        nextIndex = (nextIndex + 1) % availableChores.length;
+      }
+    }
+    setState({ selectedChore: availableChores[nextIndex] });
+  };
+
+  const handleTake = () => {
+    if (!state.selectedChore) return;
+    takeChore({
+      variables: { id: state.selectedChore.id },
+      update: () => onTaken(),
+    });
+  };
+
+  return (
+    <div className={style.pickChoreModalContent}>
+      <p className={style.pickChoreTitle}>
+        {state.selectedChore?.name || "No chores available"}
+      </p>
+      <div className={style.pickChoreModalButtons}>
+        <Button
+          buttonStyle="hollow"
+          onClick={handlePass}
+          className={style.pickChoreModalButton}
+        >
+          Pass
+        </Button>
+        <Button
+          onClick={handleTake}
+          isLoading={takeChoreData.loading}
+          className={style.pickChoreModalButton}
+        >
+          Take
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default withModal(PickChoreModal);

--- a/src/Views/ChoresView/index.tsx
+++ b/src/Views/ChoresView/index.tsx
@@ -1,12 +1,56 @@
 import { Helmet } from "react-helmet-async";
 import style from "./style.scss";
+import { CHORE_LIST_DATA } from "Schema/queries/chore.queries";
+import Loader from "Components/Loader";
+import ErrorHandler from "Components/ErrorHandler";
+import useQuery from "Hooks/useQuery";
+import Add from "Images/icons/add.svg";
+import { useLocation, useNavigate } from "react-router-dom";
+import ChoreListItem from "Views/ChoresView/ChoreListItem";
 
 const ChoresListView = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { loading, error, data, refetch } = useQuery(CHORE_LIST_DATA, {
+    fetchPolicy: "network-only",
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (loading) return <Loader />;
+  if (error) return <ErrorHandler error={error} />;
+
+  const handleAddChore = () => {
+    navigate("/chores/create");
+  };
+
+  const handleOnEdit = (choreId: string) => {
+    navigate(`/chores/edit/${choreId}`);
+  };
+
   return (
     <>
       <Helmet title={"Chores list | Imli"} />
       <section className={style.choresListWrapper}>
-        <h2 className={style.choresListTitle}>Chores list</h2>
+        <div className={style.choresListHeader}>
+          <h2 className={style.choresListTitle}>Chores list</h2>
+        </div>
+        {!loading && (!data?.chores || !data?.chores?.length) && (
+          <p>No data found</p>
+        )}
+        <ul className={style.choresList}>
+          {data.chores?.map((chore) => (
+            <ChoreListItem
+              data={chore}
+              key={chore.id}
+              onDelete={refetch}
+              onEdit={handleOnEdit}
+            />
+          ))}
+        </ul>
+        <button className={style.choresListAddButton} onClick={handleAddChore}>
+          <Add className={style.choresListAddIcon} />
+        </button>
       </section>
     </>
   );

--- a/src/Views/ChoresView/index.tsx
+++ b/src/Views/ChoresView/index.tsx
@@ -1,0 +1,15 @@
+import { Helmet } from "react-helmet-async";
+import style from "./style.scss";
+
+const ChoresListView = () => {
+  return (
+    <>
+      <Helmet title={"Chores list | Imli"} />
+      <section className={style.choresListWrapper}>
+        <h2 className={style.choresListTitle}>Chores list</h2>
+      </section>
+    </>
+  );
+};
+
+export default ChoresListView;

--- a/src/Views/ChoresView/style.scss
+++ b/src/Views/ChoresView/style.scss
@@ -1,0 +1,95 @@
+.choresView {
+  padding: 20px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+
+  h1 {
+    margin: 0;
+    color: #333;
+  }
+}
+
+.pickChoreButton {
+  padding: 12px 24px;
+  background: #007bff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: #0056b3;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 123, 255, 0.3);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.choresList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.choreItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px;
+  background: #f5f5f5;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+}
+
+.choreName {
+  font-weight: 500;
+  color: #333;
+}
+
+.choreTimestamp {
+  color: #666;
+  font-size: 0.9em;
+}
+
+.choreActions {
+  display: flex;
+  gap: 10px;
+}
+
+.takeButton {
+  padding: 8px 16px;
+  background: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover {
+    background: #45a049;
+  }
+}
+
+.deleteButton {
+  padding: 8px 16px;
+  background: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover {
+    background: #da190b;
+  }
+}

--- a/src/Views/ChoresView/style.scss
+++ b/src/Views/ChoresView/style.scss
@@ -8,7 +8,6 @@
 .choresList {
   display: grid;
   grid-gap: 15px;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   list-style: none;
   padding: 0;
 }
@@ -55,6 +54,11 @@
   flex-direction: column;
   gap: 10px;
   width: 100%;
+
+  p {
+    font-size: $fs-large;
+    text-align: center;
+  }
 }
 
 .choreListItemName {
@@ -71,17 +75,6 @@
   opacity: 0.7;
 }
 
-.choresListAddButton {
-  bottom: 15px;
-  position: fixed;
-  right: 15px;
-
-  @media (min-width: 931px) {
-    bottom: 50px;
-    right: 50px;
-  }
-}
-
 .choresListAddIcon {
   height: 50px;
   width: auto;
@@ -89,6 +82,50 @@
   path {
     fill: $secondary;
   }
+}
+
+.choresActions {
+  position: fixed;
+  bottom: 15px;
+  right: 15px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-direction: column;
+  @media (min-width: 931px) {
+    bottom: 50px;
+    right: 50px;
+  }
+}
+
+.pickChoreButton {
+  height: 50px;
+  width: 50px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: $white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.pickChoreIcon {
+  height: 24px;
+  width: 24px;
+
+  path {
+    fill: $secondary;
+  }
+}
+
+.pickChoreTitle {
+  color: $primaryText;
+  font-size: 4rem;
+  font-weight: 700;
+  margin: 0;
+  text-align: center;
+  margin-top: auto;
+  line-height: 1.2;
 }
 
 .choreListItemOption {
@@ -115,6 +152,32 @@
   display: flex;
   gap: 10px;
   justify-content: flex-end;
+}
+
+.pickChoreModalContent {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  min-height: 35dvh;
+  justify-content: space-evenly;
+  width: 550px;
+
+  @media (max-width: $small-screen) {
+    width: 100%;
+  }
+}
+
+.pickChoreModalButtons {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-top: auto;
+}
+
+.pickChoreModalButton {
+  min-width: 80px;
+  width: 100%;
 }
 
 .deleteModalButton {

--- a/src/Views/ChoresView/style.scss
+++ b/src/Views/ChoresView/style.scss
@@ -1,95 +1,172 @@
-.choresView {
-  padding: 20px;
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
-
-  h1 {
-    margin: 0;
-    color: #333;
-  }
-}
-
-.pickChoreButton {
-  padding: 12px 24px;
-  background: #007bff;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover:not(:disabled) {
-    background: #0056b3;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(0, 123, 255, 0.3);
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+.choresListWrapper {
+  color: $primaryText;
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 0 20px;
 }
 
 .choresList {
+  display: grid;
+  grid-gap: 15px;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  list-style: none;
+  padding: 0;
+}
+
+.choresListHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+
+  @media (min-width: $small-screen) {
+    gap: 15px;
+    justify-content: initial;
+  }
+
+  h2 {
+    color: $primaryText;
+  }
+}
+
+.choreListItem {
+  min-height: 150px;
+
+  @media (min-width: $small-screen) {
+    cursor: pointer;
+    padding: 0;
+  }
+}
+
+.choreListItemButton {
+  height: 100%;
+  width: 100%;
+
+  > div {
+    align-items: self-start;
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    gap: 15px;
+  }
+}
+
+.choreListItemContent {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
 }
 
-.choreItem {
-  display: flex;
+.choreListItemName {
+  color: $primaryText;
+  font-size: $fs-medium-rare;
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.choreListItemTimestamp {
+  color: $primaryText;
+  font-size: $fs-regular;
+  margin: 0;
+  opacity: 0.7;
+}
+
+.choresListAddButton {
+  bottom: 15px;
+  position: fixed;
+  right: 15px;
+
+  @media (min-width: 931px) {
+    bottom: 50px;
+    right: 50px;
+  }
+}
+
+.choresListAddIcon {
+  height: 50px;
+  width: auto;
+
+  path {
+    fill: $secondary;
+  }
+}
+
+.choreListItemOption {
   align-items: center;
+  color: $primaryText;
+  display: flex;
   justify-content: space-between;
-  padding: 15px;
-  background: #f5f5f5;
-  border-radius: 8px;
-  border: 1px solid #ddd;
+  width: 100%;
 }
 
-.choreName {
-  font-weight: 500;
-  color: #333;
+.deleteModalContent {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
 }
 
-.choreTimestamp {
-  color: #666;
-  font-size: 0.9em;
+.deleteModalTitle {
+  color: $primaryText;
+  margin: 0;
 }
 
-.choreActions {
+.deleteModalButtons {
   display: flex;
   gap: 10px;
+  justify-content: flex-end;
 }
 
-.takeButton {
-  padding: 8px 16px;
-  background: #4caf50;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+.deleteModalButton {
+  min-width: 80px;
+}
 
-  &:hover {
-    background: #45a049;
+.choreFormContainer {
+  margin: 0 auto;
+  max-width: 600px;
+  padding: 0 20px;
+}
+
+.choreFormWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.choreFormTitle {
+  color: $primaryText;
+  margin: 0;
+  text-align: center;
+}
+
+.choreForm {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.choreFormField {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  label {
+    color: $primaryText;
+    font-size: $fs-regular;
+    font-weight: 500;
   }
 }
 
-.deleteButton {
-  padding: 8px 16px;
-  background: #f44336;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+.choreFormButtons {
+  display: flex;
+  gap: 15px;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
 
-  &:hover {
-    background: #da190b;
-  }
+.addSuccessful {
+  color: $green;
+  font-size: $fs-regular;
+  text-align: center;
+  margin: 0;
 }

--- a/src/Views/ProductListView/ProductItem.tsx
+++ b/src/Views/ProductListView/ProductItem.tsx
@@ -30,7 +30,6 @@ interface State {
 const ProductItem = ({
   id,
   name,
-  index,
   onCompleted,
   onDelete,
   isCompleted,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import "../public/sw";
 const httpLink = createHttpLink({
   uri: process.env.CLIENT_GRAPHQL_LINK,
 });
+
 const authLink = setContext((_, { headers }) => {
   const token = getCookieData("auth");
 
@@ -26,7 +27,7 @@ const authLink = setContext((_, { headers }) => {
     headers: {
       ...headers,
       "Cache-Control": "max-age=3600",
-      authorization: `${token}`,
+      Authorization: `Bearer ${token}`,
     },
   };
 });


### PR DESCRIPTION
**Client-Side Changes Summary**

### Added:

New PickChoreModal component with random chore selection
Dice SVG icon for the pick button
Separate SCSS classes for pick modal styling
Lazy query for filtered chore fetching
New route: /chores/pick (though this might be modal-based, not a separate route)

### Changed:

Chores view now has two action buttons: create (+) and pick (dice)
Pick button opens modal showing random chore with "Pass" and "Take" options
"Pass" selects new random chore, "Take" calls takeChore mutation
Modal uses lazy query with days: 5 filter to avoid rerendering main list
Button layout changed from single floating button to side-by-side action buttons

### Modified:

CHORE_LIST_DATA query now accepts optional days parameter
Chores view state management to handle modal open/close
Button positioning and styling for dual-action layout
Note: Looking at the implementation, the pick functionality is actually a modal overlay rather than a separate route/view - it's integrated into the existing Chores view.