### PR TITLE
7feat: UI polish, editor skeleton, and toast notifications

### DIFF
--- a/src/Components/Box/index.tsx
+++ b/src/Components/Box/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   isLoading?: boolean;
   children: ReactNode | ReactNode[];
   dropdownComponent?: ReactNode;
+  className?: string;
 }
 
 type Elements = HTMLDivElement | HTMLParagraphElement | HTMLLIElement;
@@ -24,6 +25,7 @@ const Box = forwardRef<Elements, Props>(
     isLoading = false,
     isDraggable,
     dropdownComponent,
+    className = "",
   }) => {
     const {
       attributes,
@@ -51,7 +53,7 @@ const Box = forwardRef<Elements, Props>(
     );
 
     const renderedContent = isLoading ? <Loader /> : boxContent;
-    const baseClasses = "rounded-xl bg-surface-alt p-4 shadow-sm transition-shadow hover:shadow-md";
+    const baseClasses = `rounded-xl bg-surface-alt p-4 shadow-sm transition-shadow hover:shadow-md ${className}`;
 
     if (isDraggable) {
       return (

--- a/src/Components/Skeleton/index.tsx
+++ b/src/Components/Skeleton/index.tsx
@@ -1,0 +1,16 @@
+import { CSSProperties } from "react";
+
+interface Props {
+  className?: string;
+  style?: CSSProperties;
+}
+
+const Skeleton = ({ className = "", style }: Props) => (
+  <div
+    aria-hidden="true"
+    style={style}
+    className={`animate-pulse rounded-md bg-surface-alt ${className}`}
+  />
+);
+
+export default Skeleton;

--- a/src/Providers/ToastProvider/index.tsx
+++ b/src/Providers/ToastProvider/index.tsx
@@ -1,0 +1,109 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type ToastVariant = "success" | "error" | "info";
+
+interface Toast {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastApi {
+  show: (message: string, variant?: ToastVariant, durationMs?: number) => void;
+  success: (message: string, durationMs?: number) => void;
+  error: (message: string, durationMs?: number) => void;
+  info: (message: string, durationMs?: number) => void;
+}
+
+const defaultApi: ToastApi = {
+  show: () => null,
+  success: () => null,
+  error: () => null,
+  info: () => null,
+};
+
+const ToastContext = createContext<ToastApi>(defaultApi);
+
+const DEFAULT_DURATION = 3000;
+
+const variantClasses: Record<ToastVariant, string> = {
+  success: "border-success/50 bg-surface-alt text-success",
+  error: "border-danger/50 bg-surface-alt text-danger",
+  info: "border-text/30 bg-surface-alt text-text",
+};
+
+interface Props {
+  children: ReactNode;
+}
+
+const ToastProvider = ({ children }: Props) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timeoutsRef = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
+  const idRef = useRef(0);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    if (timeoutsRef.current[id]) {
+      clearTimeout(timeoutsRef.current[id]);
+      delete timeoutsRef.current[id];
+    }
+  }, []);
+
+  const show = useCallback(
+    (
+      message: string,
+      variant: ToastVariant = "info",
+      durationMs: number = DEFAULT_DURATION,
+    ) => {
+      const id = ++idRef.current;
+      setToasts((prev) => [...prev, { id, message, variant }]);
+      timeoutsRef.current[id] = setTimeout(() => dismiss(id), durationMs);
+    },
+    [dismiss],
+  );
+
+  useEffect(() => {
+    return () => {
+      Object.values(timeoutsRef.current).forEach(clearTimeout);
+    };
+  }, []);
+
+  const api: ToastApi = {
+    show,
+    success: (message, durationMs) => show(message, "success", durationMs),
+    error: (message, durationMs) => show(message, "error", durationMs),
+    info: (message, durationMs) => show(message, "info", durationMs),
+  };
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <div
+        aria-live="polite"
+        className="pointer-events-none fixed bottom-5 left-1/2 z-50 flex w-full max-w-sm -translate-x-1/2 flex-col gap-2 px-4"
+      >
+        {toasts.map((toast) => (
+          <button
+            type="button"
+            key={toast.id}
+            onClick={() => dismiss(toast.id)}
+            className={`pointer-events-auto w-full rounded-lg border px-4 py-3 text-sm shadow-lg transition-opacity ${variantClasses[toast.variant]}`}
+          >
+            {toast.message}
+          </button>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);
+export default ToastProvider;

--- a/src/Views/ChoresView/ChoreListItem.tsx
+++ b/src/Views/ChoresView/ChoreListItem.tsx
@@ -34,10 +34,11 @@ const ChoreListItem = ({ data, onDelete, onEdit }: Props) => {
 
   return (
     <>
-      <li className="min-h-[150px]">
+      <li className="h-full min-h-[150px]">
         <div className="h-full w-full">
           <Box
             as="div"
+            className="h-full"
             dropdownComponent={
               <Dropdown>
                 <Button

--- a/src/Views/MealView/MealForm.tsx
+++ b/src/Views/MealView/MealForm.tsx
@@ -12,28 +12,29 @@ import {
   MEAL_NAME_MUTATION,
 } from "Schema/mutations/meal.mutations";
 import Loader from "Components/Loader";
+import Skeleton from "Components/Skeleton";
 import { editorConfig } from "Views/MealView/constants";
 import useQuery from "Hooks/useQuery";
 import { MEAL_LIST_DATA } from "Schema/queries/meal.queries";
 import { useNavigate, useParams } from "react-router-dom";
 import ErrorHandler from "Components/ErrorHandler";
 import { ROUTE_MEAL_PAGE } from "App/constants";
+import { useToast } from "Providers/ToastProvider";
 
 interface State {
   mealData?: DeepExtractTypeSkipArrays<MealListQuery, ["meals"]>;
   isLoaded: boolean;
-  addSuccessful: boolean;
 }
 
 const MealForm = () => {
   const [state, setState] = useState<State>({
     isLoaded: false,
-    addSuccessful: false,
     mealData: undefined,
   });
 
   const { id } = useParams();
   const navigate = useNavigate();
+  const toast = useToast();
 
   const { loading, error } = useQuery(MEAL_LIST_DATA, {
     skip: !id,
@@ -71,8 +72,8 @@ const MealForm = () => {
             mealInstructionsRef.current || state.mealData.instructions,
         },
         update: () => {
-          setState({ addSuccessful: true });
           navigate(ROUTE_MEAL_PAGE);
+          toast.success("Meal updated successfully");
         },
       });
       return;
@@ -85,8 +86,9 @@ const MealForm = () => {
         instructions: mealInstructionsRef.current,
       },
       update: () => {
-        formRef.current.reset();
-        setState({ addSuccessful: true });
+        formRef.current?.reset();
+        navigate(ROUTE_MEAL_PAGE);
+        toast.success("Meal added successfully");
       },
     });
   };
@@ -109,15 +111,19 @@ const MealForm = () => {
           ref={mealInputRef}
           defaultValue={state.mealData?.name}
         />
-        <div className="min-h-[500px]">
-          {!state.isLoaded && <Loader />}
-          <Editor
-            initialValue={state.mealData?.instructions}
-            init={editorConfig}
-            apiKey={import.meta.env.VITE_CLIENT_TINY_MCE_EDITOR_KEY}
-            onEditorChange={onEditorChange}
-            onInit={() => setState({ isLoaded: true })}
-          />
+        <div className="relative min-h-[500px]">
+          {!state.isLoaded && (
+            <Skeleton className="absolute inset-0 h-[500px] w-full" />
+          )}
+          <div className={!state.isLoaded ? "invisible" : undefined}>
+            <Editor
+              initialValue={state.mealData?.instructions}
+              init={editorConfig}
+              apiKey={import.meta.env.VITE_CLIENT_TINY_MCE_EDITOR_KEY}
+              onEditorChange={onEditorChange}
+              onInit={() => setState({ isLoaded: true })}
+            />
+          </div>
         </div>
         <IngredientContainer
           onInput={setInputData}
@@ -125,11 +131,6 @@ const MealForm = () => {
           error={addMealData?.error || editMealData.error}
           isLoading={addMealData.loading || editMealData.loading}
         />
-        {state.addSuccessful && (
-          <span className="text-sm text-success">
-            Meal has been successfully added!
-          </span>
-        )}
       </form>
     </div>
   );

--- a/src/Views/MealView/MealListItem.tsx
+++ b/src/Views/MealView/MealListItem.tsx
@@ -43,10 +43,11 @@ const MealListItem = ({ data, onDelete, onEdit }: Props) => {
 
   return (
     <>
-      <li className="min-h-[200px] cursor-pointer">
+      <li className="h-full min-h-[200px] cursor-pointer">
         <div role="button" onClick={handlePreviewClick} className="h-full w-full">
           <Box
             as="div"
+            className="h-full"
             title={data?.name}
             dropdownComponent={
               <Dropdown>

--- a/src/Views/ProductListView/index.tsx
+++ b/src/Views/ProductListView/index.tsx
@@ -69,14 +69,16 @@ const Index = () => {
       <Helmet title={"Product list | Imli"} />
       <section className="mx-auto flex h-[calc(100dvh-80px)] max-w-lg flex-col text-text md:h-[calc(100dvh-40px)]">
         <h2 className="mb-4 text-2xl font-bold text-text">Product list</h2>
-        <ProductList
-          loading={loading}
-          onChange={saveOnChange}
-          listData={state.listData}
-          onDelete={handleDeleteItem}
-          onRename={handleProductRename}
-          onCompleted={handleProductComplete}
-        />
+        <div className="flex min-h-0 flex-1 flex-col">
+          <ProductList
+            loading={loading}
+            onChange={saveOnChange}
+            listData={state.listData}
+            onDelete={handleDeleteItem}
+            onRename={handleProductRename}
+            onCompleted={handleProductComplete}
+          />
+        </div>
         <ErrorHandler error={error} />
         <ProductAddForm onChange={updateList} />
         <ProductListButtons onChange={refetch} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { getCookieData } from "Utilities/cookieParser";
 import { Helmet, HelmetProvider } from "react-helmet-async";
 import Authentication from "Providers/Authentication";
 import ThemeSwitcher from "Providers/ThemeProvider";
+import ToastProvider from "Providers/ToastProvider";
 
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
@@ -54,7 +55,9 @@ container.render(
           <Helmet title="Imli Home Utility System" />
           <Authentication>
             <ThemeSwitcher>
-              <App />
+              <ToastProvider>
+                <App />
+              </ToastProvider>
             </ThemeSwitcher>
           </Authentication>
         </BrowserRouter>


### PR DESCRIPTION
- Stretch meal/chore cards to full grid row height via opt-in className on Box
- Add reusable Skeleton component; use it as TinyMCE editor placeholder
- Navigate to meal list after recipe create (parity with edit flow)
- Keep product list input pinned to bottom across loading/empty/populated states
- Introduce ToastProvider + useToast hook; fire success toast on meal create/edit